### PR TITLE
FIX: template paths mutation and rendering issue

### DIFF
--- a/video_xblock/utils.py
+++ b/video_xblock/utils.py
@@ -52,9 +52,7 @@ def render_template(template_name, **context):
     Returns: django.utils.safestring.SafeText
     """
     template_dirs = [os.path.join(os.path.dirname(__file__), 'static/html')]
-    engine = Engine.get_default()
-    engine.dirs = template_dirs
-    engine.debug = True
+    engine = Engine(dirs=template_dirs, debug=True)
     html = engine.get_template(template_name)
 
     return html_parser.unescape(

--- a/video_xblock/utils.py
+++ b/video_xblock/utils.py
@@ -10,6 +10,7 @@ import os.path
 import pkg_resources
 
 from django.template import Engine, Context, Template
+
 from xblockutils.resources import ResourceLoader
 
 from .constants import TranscriptSource
@@ -51,13 +52,8 @@ def render_template(template_name, **context):
 
     Returns: django.utils.safestring.SafeText
     """
-    template_dirs = [os.path.join(os.path.dirname(__file__), 'static/html')]
-    engine = Engine(dirs=template_dirs, debug=True)
-    html = engine.get_template(template_name)
-
-    return html_parser.unescape(
-        html.render(Context(context))
-    )
+    html = loader.render_django_template('static/html/{}'.format(template_name), context)
+    return html_parser.unescape(html)
 
 
 def ugettext(text):


### PR DESCRIPTION
## PR description
Upon rendering the video block, the templates path were overwritten and messed up due to which the logout page and any page that used `main_django.html` file as base template were not rendered correctly.

